### PR TITLE
Bump version to 0.6.8

### DIFF
--- a/lib/hydra/remote_identifier/version.rb
+++ b/lib/hydra/remote_identifier/version.rb
@@ -1,5 +1,5 @@
 module Hydra
   module RemoteIdentifier
-    VERSION = "0.6.7"
+    VERSION = "0.6.8"
   end
 end


### PR DESCRIPTION
Since this change makes an update to the dependencies of gem should the version number be bumped to 0.7.0 since the dependency that changed was increased by a minor version or is 0.6.8 the correct version number?